### PR TITLE
Improve recibida header and styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
   <header class="hero hero-big">
     <div class="header-content">
       <h1>Franco Rodríguez</h1>
-      <p class="tagline">Líder Técnico</p>
+      <p class="tagline" data-phrases='["Líder Técnico","Apasionado por la tecnología","Desarrollador de software","Experto en IA"]'>Líder Técnico</p>
       <nav class="nav-links">
         <a href="#about">Sobre mí</a>
         <a href="#projects">Proyectos</a>

--- a/recibida.html
+++ b/recibida.html
@@ -15,12 +15,15 @@
   <header class="hero hero-big">
     <div class="header-content">
       <h1>¡Se viene mi recibida!</h1>
-      <p class="tagline">Sumate al festejo</p>
+      <p class="tagline" data-phrases='["Ingeniero Informático"]'>Ingeniero Informático</p>
     </div>
+    <a href="#info" class="scroll-down" aria-label="Desplazar hacia el contenido">
+      <i class="fas fa-chevron-down"></i>
+    </a>
   </header>
 
   <main>
-    <section class="content-section fade-in">
+    <section id="info" class="content-section fade-in">
       <h2>¿Cuándo rindo?</h2>
       <p>El final es el <strong>miércoles 23 de julio</strong>. Ese día no me dan la nota, pero seguramente me la confirmen en la misma semana.</p>
       <p>Para festejar tranquilos, la idea es juntarnos el finde siguiente.</p>
@@ -34,10 +37,16 @@
 
     <section class="content-section fade-in">
       <h2>Fechas posibles</h2>
-      <ul>
-        <li><strong>Sábado 26 de julio</strong> - alrededor de las 19 hs en UADE.</li>
-        <li><strong>Domingo 27 de julio</strong> - alrededor de las 16 hs en UADE.</li>
-      </ul>
+      <div class="date-cards">
+        <div class="date-card">
+          <h3>Sábado 26 de julio</h3>
+          <p>Alrededor de las 19 hs en UADE.</p>
+        </div>
+        <div class="date-card">
+          <h3>Domingo 27 de julio</h3>
+          <p>Alrededor de las 16 hs en UADE.</p>
+        </div>
+      </div>
     </section>
 
     <section class="content-section alt-bg fade-in">

--- a/scripts.js
+++ b/scripts.js
@@ -13,12 +13,20 @@ document.querySelectorAll('.fade-in').forEach(section => {
 
 // Simple typewriter effect for the tagline
 const tagline = document.querySelector('.tagline');
-const phrases = [
+let phrases = [
   'Líder Técnico',
   'Apasionado por la tecnología',
   'Desarrollador de software',
   'Experto en IA'
 ];
+
+if (tagline && tagline.dataset.phrases) {
+  try {
+    phrases = JSON.parse(tagline.dataset.phrases);
+  } catch (e) {
+    phrases = [tagline.textContent];
+  }
+}
 let phraseIndex = 0;
 let charIndex = 0;
 let removing = false;

--- a/styles.css
+++ b/styles.css
@@ -205,16 +205,17 @@ footer a {
 }
 
 .button {
-  background-color: #0069d9;
-  color: white;
+  background: linear-gradient(45deg, #0069d9, #0053a4);
+  color: #fff;
   padding: 12px 24px;
   border-radius: 5px;
   text-decoration: none;
   font-weight: bold;
   display: inline-block;
-  margin-top: 20px;
+  margin: 20px 0;
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
   transition: background 0.3s, transform 0.2s, box-shadow 0.2s;
+  border: none;
 }
 
 .button.small {
@@ -263,4 +264,52 @@ footer a {
 .to-top.show {
   opacity: 1;
   pointer-events: auto;
+}
+
+/* Scroll indicator arrow */
+.scroll-down {
+  position: absolute;
+  bottom: 15px;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 2rem;
+  color: #fff;
+  animation: arrow-blink 1.5s infinite;
+  z-index: 1;
+}
+
+@keyframes arrow-blink {
+  0%, 100% {
+    opacity: 1;
+    transform: translate(-50%, 0);
+  }
+  50% {
+    opacity: 0.4;
+    transform: translate(-50%, 10px);
+  }
+}
+
+/* Date cards */
+.date-cards {
+  display: flex;
+  justify-content: center;
+  gap: 20px;
+  flex-wrap: wrap;
+  margin-top: 20px;
+}
+
+.date-card {
+  background: #ffffff;
+  padding: 20px;
+  border-radius: 10px;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  flex: 1 1 200px;
+  max-width: 250px;
+}
+
+@media (max-width: 600px) {
+  .date-cards {
+    flex-direction: column;
+    align-items: center;
+  }
 }


### PR DESCRIPTION
## Summary
- add per-page phrases data for tagline typing effect
- animate scroll hint arrow in recibida header
- show possible dates as cards and tweak button spacing
- restyle generic button

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6871e4dd491883319237d4492154335a