### PR TITLE
Traducir README al español argentino

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
 # frann
+
+## Propósito
+
+Este repositorio contiene el código fuente de mi sitio web personal. El sitio junta experimentos rápidos y páginas que uso para compartir invitaciones y pequeñas utilidades con amigas y amigos. Es un sitio estático alojado en GitHub Pages.
+
+## Cómo previsualizarlo en tu máquina
+
+Podés usar cualquier servidor web estático para probar las páginas. Si tenés Python instalado, ejecutá:
+
+```bash
+python3 -m http.server
+```
+
+Después abrí `http://localhost:8000/index.html` en tu navegador.
+
+También podés abrir cualquier archivo HTML directamente sin servidor, aunque algunas funciones pueden andar mejor con uno.
+
+## Páginas
+
+- **index.html** – Página principal con una breve bio, enlaces de contacto y proyectos destacados.
+- **alarmas.html** – Planificador diario que permite configurar alarmas y actividades.
+- **starbucks.html** – Muestra los precios del café del día.
+- **recibida.html** – Invitación a mi festejo de graduación de ingeniería.
+- **cumple.html** – Invitación para mi cumple.
+- **cosmere.html** – Lista visual de los libros de Brandon Sanderson y su orden de lectura.


### PR DESCRIPTION
## Summary
- traducir la documentación principal al español argentino
- explicar cómo previsualizar el sitio con Python
- describir brevemente cada página HTML

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687869312cec8331999ab62d30970e1e